### PR TITLE
Disable default features for `cairo-rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "plotters-cairo"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Hao Hou <haohou302@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "Plotters Cairo backend"
 homepage = "https://plotters-rs.github.io"
@@ -12,13 +12,12 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-plotters-backend = "^0.3.0"
+plotters-backend = "^0.3.2"
 
 [dependencies.cairo-rs]
-version = "0.9.1"
+version = "0.15.1"
 default_features = false
 features = ["ps"]
 
 [dev-dependencies]
-plotters = {version = "^0.3.0", default_features = false}
-
+plotters = {version = "^0.3.1", default_features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ plotters-backend = "^0.3.0"
 
 [dependencies.cairo-rs]
 version = "0.9.1"
+default_features = false
 features = ["ps"]
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 mod backend;
 
-pub use backend::CairoBackend;
+pub use backend::{CairoBackend, CairoError};


### PR DESCRIPTION
First of all thank you very much for this crate/code :-) It's working flawlessly.
This PR disables default features for `cairo-rs` (e.g. `glib`), which are not needed when e.g. using cairo only as rendering helper. Required features are already present in `features` field.