### PR TITLE
Proposal to use git-master dependencies for collaboration, testing, and CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 cairo-rs = { version = "0.15.1", default-features = false }
 
 [dependencies.plotters-backend]
-branch = "master"
 git = "https://github.com/plotters-rs/plotters-backend"
 # version = "0.3.1"
 
@@ -21,7 +20,6 @@ git = "https://github.com/plotters-rs/plotters-backend"
 cairo-rs = { version = "0.15.1", features = ["ps"], default-features = false }
 
 [dev-dependencies.plotters]
-branch = "master"
 default_features = false
 git = "https://github.com/plotters-rs/plotters"
 # version = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,18 @@ repository = "https://github.com/plotters-rs/plotters-cairo"
 readme = "README.md"
 
 [dependencies]
-plotters-backend = "^0.3.0"
 cairo-rs = { version = "0.15.1", default-features = false }
 
+[dependencies.plotters-backend]
+branch = "master"
+git = "https://github.com/plotters-rs/plotters-backend"
+# version = "0.3.1"
+
 [dev-dependencies]
-plotters = { version = "^0.3.0", default_features = false }
 cairo-rs = { version = "0.15.1", features = ["ps"], default-features = false }
+
+[dev-dependencies.plotters]
+branch = "master"
+default_features = false
+git = "https://github.com/plotters-rs/plotters"
+# version = "0.3.1"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -287,6 +287,7 @@ impl<'a> DrawingBackend for CairoBackend<'a> {
             FontTransform::Rotate90 => 90.0,
             FontTransform::Rotate180 => 180.0,
             FontTransform::Rotate270 => 270.0,
+            FontTransform::RotateAngle(angle) => angle as f64,
         } / 180.0
             * std::f64::consts::PI;
 


### PR DESCRIPTION
This proposal aims to improve collaboration, testing, and CI by altering the version of the `plotters-backend` and `plotters` dependencies in `Cargo.toml`. Instead of using the stable versions of those crates, the `git-master` versions are used.

Using the `git-master` versions of the `plotters-` crates is vital for pre-release quality assurance and frustration-free collaboration in Plotters. It also reduces surprises at release time.

This is part of the proposal discussed on plotters-rs/plotters#373