### PR TITLE
Updated cairo-rs version to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ repository = "https://github.com/plotters-rs/plotters-cairo"
 readme = "README.md"
 
 [dependencies]
-cairo-rs = { version = "0.20", default-features = false }
+cairo-rs = { version = "0.21", default-features = false }
 
 [dependencies.plotters-backend]
 version = "0.3.5"
 
 [dev-dependencies]
-cairo-rs = { version = "0.20", features = ["ps"], default-features = false }
+cairo-rs = { version = "0.21", features = ["ps"], default-features = false }
 
 [dev-dependencies.plotters]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plotters-cairo"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Hao Hou <haohou302@gmail.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Updated the cairo-rs version requirement to 0.21 in order to be compatible with the latest gtk4 version 0.10 (which requires cairo-rs 0.21, see https://crates.io/crates/gtk4/0.10.0/dependencies)